### PR TITLE
[PLTCI] Remove inclusiveness workflow

### DIFF
--- a/.github/workflows/inclusiveness.yaml
+++ b/.github/workflows/inclusiveness.yaml
@@ -1,9 +1,0 @@
-name: inclusiveness-check
-on: [pull_request]
-jobs:
-  inclusiveness-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - id: inclusiveness-check
-        uses: Glovo/gha-inclusiveness-check/inclusiveness-check@v1.0.0


### PR DESCRIPTION
As part of cost cleanup we noticed that inclusiveness-check if one of the main offenders. This PR removes the inclusiveness check due to the number of false positives and the running costs, in Platform we believe we can count on the human part of the review process of any PR to spot and correct non-inclusive wording, instead of the current approach. If you need more details please feel free to reach out to tech-infra.

[_Created by Sourcegraph batch change `glovo/remove-inclusiveness-checks-workflow`._](https://glovo.sourcegraph.com/organizations/glovo/batch-changes/remove-inclusiveness-checks-workflow)